### PR TITLE
Deleted fixed account number

### DIFF
--- a/backend/layers/requirements.txt
+++ b/backend/layers/requirements.txt
@@ -1,3 +1,4 @@
 requests==2.22.0
 cognitojwt==1.1.0
 boto3==1.10.34
+aws-lambda-powertools

--- a/backend/shoppingcart-service.yaml
+++ b/backend/shoppingcart-service.yaml
@@ -25,8 +25,6 @@ Globals:
     Tracing: Active
     AutoPublishAlias: live
     Runtime: python3.8
-    Layers:
-      - !Sub arn:aws:lambda:${AWS::Region}:017000801446:layer:AWSLambdaPowertoolsPython:3
     Environment:
       Variables:
         TABLE_NAME: !Ref DynamoDBShoppingCartTable

--- a/backend/shoppingcart-service.yaml
+++ b/backend/shoppingcart-service.yaml
@@ -32,6 +32,8 @@ Globals:
         ALLOWED_ORIGIN: !Ref AllowedOrigin
         POWERTOOLS_SERVICE_NAME: shopping-cart
         POWERTOOLS_METRICS_NAMESPACE: ecommerce-app
+        POWERTOOLS_LOGGER_SAMPLE_RATE: 0.5
+
   Api:
     EndpointConfiguration: REGIONAL
     TracingEnabled: true


### PR DESCRIPTION
*Description of changes:*
For my personal use I reverted the last commit and now everything is working fine. In the last commit there is an account number included which gives me permission errors on Lambda permissions. 

*This is causing my error:*
Layers:
-  !Sub arn:aws:lambda:${AWS::Region}:017000801446:layer:AWSLambdaPowertoolsPython:3

*Below the error message I get:*
<Resource handler returned message: "User: arn:aws:sts::xxxxxxxxxxxxx:assumed-role/CartApp-AmplifyRole-12ALSHSJD66U4/BuildSession is not authorized to perform: lambda:GetLayerVersion on resource: arn:aws:lambda:eu-west-1:017000801446:layer:AWSLambdaPowertoolsPython:3 because no identity-based policy allows the lambda:GetLayerVersion action (Service: Lambda, Status Code: 403, Request ID: 6ffc5587-713f-4551-bf5c-ce545a7b9fce, Extended Request ID: null)" (RequestToken: 51f01316-f515-75ed-5828-ace58377ba8d, HandlerErrorCode: AccessDenied)>

*I also included POWERTOOLS_LOGGER_SAMPLE_RATE: 0.5 to demonstrate this great functionality but this is only for educational purposes, it can as well be deleted.*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
